### PR TITLE
Fix Dockerfile and add README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ COPY *.m .
 # ------------------------------
 # 4) Archivos web
 # ------------------------------
-RUN mkdir -p /opt/octave-web
-COPY octave-web/ /opt/octave-web/
 
 # ------------------------------
 # 5) Script lanzador

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Octave Docker
+
+Este contenedor provee una interfaz web para ejecutar Octave utilizando [GoTTY](https://github.com/yudai/gotty). Al iniciar la imagen se expone un servidor en el puerto **8080**. Accede a `http://localhost:8080` desde tu navegador para usar el terminal de Octave.
+
+Si prefieres trabajar directamente desde la consola en lugar de la web, puedes sobreescribir el *entrypoint* al ejecutar el contenedor:
+
+```bash
+docker run -it --rm --entrypoint /usr/local/bin/entrypoint.sh ghcr.io/nemog17/octave-docker
+```
+
+El script `entrypoint.sh` inicia Octave en modo no interactivo cuando se pasa el nombre de un script `.m` a través del parámetro `?arg`. Sin argumentos se abre el REPL de Octave.
+
+Para construir la imagen localmente:
+
+```bash
+docker build -t octave-docker .
+```
+
+Luego ejecútala con:
+
+```bash
+docker run -it --rm -p 8080:8080 octave-docker
+```
+


### PR DESCRIPTION
## Summary
- remove stray octave-web copy from Dockerfile
- add README with usage instructions

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af07652dc8321839c326006dce180