### PR TITLE
Adjust Octave prompt when spawning REPL

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,6 +20,9 @@ wss.on('connection', (ws) => {
     env: process.env
   });
 
+  // Adjust prompts to behave like Octave Online and disable paging
+  shell.write("PS1('>> '); PS2(''); more off;\n");
+
   shell.on('data', (data) => {
     ws.send(data);
   });


### PR DESCRIPTION
## Summary
- configure Octave prompt to mimic Octave Online
- disable paging so results are returned immediately

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b1d52f96083219b7deb4fe3ad497e