### PR TITLE
Auto refresh workspace variables

### DIFF
--- a/public/console.js
+++ b/public/console.js
@@ -84,7 +84,6 @@ inputEl.addEventListener('keydown', e => {
     const cmd = inputEl.value;
     inputEl.value = '';
     ws.send(cmd + '\n');
-    setTimeout(sendVarRequest, 50);
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -22,13 +22,24 @@ wss.on('connection', (ws) => {
 
   // Adjust prompts to behave like Octave Online and disable paging
   shell.write("PS1('>> '); PS2(''); more off;\n");
+  shell.write('printf("<VARS>%s</VARS>\\n", strjoin(who(), ","));\n');
 
   shell.on('data', (data) => {
     ws.send(data);
   });
 
   ws.on('message', (msg) => {
-    shell.write(msg.toString());
+    const input = msg.toString();
+    shell.write(input);
+
+    const isVarCmd = input.startsWith('printf("<VARS>') || input.startsWith('printf("<VAL:');
+
+    if(!isVarCmd){
+      if(!input.endsWith('\n')){
+        shell.write('\n');
+      }
+      shell.write('printf("<VARS>%s</VARS>\\n", strjoin(who(), ","));\n');
+    }
   });
 
   ws.on('close', () => {


### PR DESCRIPTION
## Summary
- backend: after every command print the workspace variable list to the PTY
- frontend: no longer sends a separate var-update command after user input

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b217325ac8321a5a0d3dbe526b26c