### PR TITLE
Fix Octave prompt and enlarge console font

### DIFF
--- a/public/console.js
+++ b/public/console.js
@@ -50,10 +50,7 @@ function connect(){
   const loc = window.location;
   const wsUrl = (loc.protocol === 'https:' ? 'wss://' : 'ws://') + loc.host;
   ws = new WebSocket(wsUrl);
-  ws.addEventListener('open', () => {
-    sendVarRequest();
-  });
-    ws.addEventListener('message', evt => {
+  ws.addEventListener('message', evt => {
       const text = evt.data;
       if(text.startsWith('<VARS>') && text.includes('</VARS>')){
         const vars = text.substring(6, text.indexOf('</VARS>'));

--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,8 @@
 <style>
 body{margin:0;height:100vh;display:flex;font-family:monospace;background:#1e1e1e;color:#dcdcdc;}
 #console{flex:2;display:flex;flex-direction:column;border-right:1px solid #555;padding:10px;}
-#output{flex:1;overflow:auto;white-space:pre-wrap;background:#000;padding:5px;margin:0;}
-#command-input{border:none;padding:5px;background:#333;color:#dcdcdc;}
+#output{flex:1;overflow:auto;white-space:pre-wrap;background:#000;padding:5px;margin:0;font-size:18px;}
+#command-input{border:none;padding:5px;background:#333;color:#dcdcdc;font-size:18px;}
 #vars-panel{flex:1;padding:10px;overflow:auto;}
 #vars-panel h3{margin-top:0;}
 #vars-list li{margin-bottom:4px;}

--- a/server.js
+++ b/server.js
@@ -14,15 +14,13 @@ app.get('/', (req, res) => {
 });
 
 wss.on('connection', (ws) => {
-  const shell = pty.spawn('octave', ['--silent', '--no-line-editing'], {
+  const shell = pty.spawn('octave', ['--silent', '--no-line-editing', '--eval', 'more off'], {
     cols: 80,
     rows: 24,
     env: process.env
   });
 
-  // Adjust prompts to behave like Octave Online and disable paging
-  shell.write("PS1('>> '); PS2(''); more off;\n");
-  shell.write('printf("<VARS>%s</VARS>\\n", strjoin(who(), ","));\n');
+  // Default prompts are preserved
 
   shell.on('data', (data) => {
     ws.send(data);


### PR DESCRIPTION
## Summary
- keep Octave default prompts
- stop sending initial variable request
- enlarge terminal font size

## Testing
- `npm install --silent`
- `node server.js` *(fails: octave: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2501b62083218bd45f27e2f08421