### PR TITLE
Fix Octave clean exit

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,7 +41,15 @@ wss.on('connection', (ws) => {
   });
 
   ws.on('close', () => {
-    shell.kill();
+    // Ask Octave to terminate gracefully before killing the PTY.
+    try {
+      shell.write('quit;\n');
+    } catch (e) {}
+    setTimeout(() => {
+      try {
+        shell.kill();
+      } catch (e) {}
+    }, 100);
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure Octave processes exit gracefully when the websocket disconnects

## Testing
- `npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b27cf80fc83218e39c3bbb74f8bb7