### PR TITLE
Use ttyd instead of downloading Gotty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,41 +2,27 @@
 FROM debian:bookworm-slim
 
 # ------------------------------
-# 1) Sistema base + Octave
+# 1) Sistema base + Octave + ttyd
 # ------------------------------
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        octave gnuplot-nox ca-certificates curl && \
+        octave gnuplot-nox ca-certificates ttyd && \
     rm -rf /var/lib/apt/lists/*
 ENV GNUTERM=dumb
 
 # ------------------------------
-# 2) GoTTY (terminal web)
-# ------------------------------
-ARG GOTTY_VERSION=1.0.1
-RUN curl -L https://github.com/yudai/gotty/releases/download/v${GOTTY_VERSION}/gotty_linux_amd64.tar.gz \
-        | tar -xz -C /usr/local/bin && \
-    chmod +x /usr/local/bin/gotty
-
-# ------------------------------
-# 3) Ejercicios
+# 2) Ejercicios
 # ------------------------------
 WORKDIR /opt/exercises
 COPY *.m .
 
 # ------------------------------
-# 4) Archivos web
-# ------------------------------
-RUN mkdir -p /opt/octave-web
-COPY octave-web/* /opt/octave-web/
-
-# ------------------------------
-# 5) Script lanzador
+# 3) Script lanzador
 # ------------------------------
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8080
-ENTRYPOINT ["bash","-lc","exec gotty --permit-arguments --permit-write --index /opt/octave-web/index.html --port 8080 --title-format Octave /usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["ttyd","-p","8080","bash","-lc","/usr/local/bin/entrypoint.sh"]
 
 


### PR DESCRIPTION
## Summary
- install `ttyd` from Debian repositories to provide the web terminal
- drop external Gotty download and related assets
- run `ttyd` as the container entrypoint

## Testing
- `bash -n entrypoint.sh`
- `docker build -t octave-docker-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897da37530083218cb04a890123ac63