### PR TITLE
Improve entrypoint default script handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Primer argumento que llega vía ?arg=<fichero.m>
 file="$1"
+
+# Si no se pasa argumento, intenta usar el primer script en /opt/exercises
+if [[ -z "$file" ]]; then
+  file=$(find /opt/exercises -maxdepth 1 -name '*.m' 2>/dev/null | head -n 1)
+fi
 
 # Si viene solo el nombre, lo buscamos en /opt/exercises
 if [[ -n "$file" ]]; then
@@ -10,6 +14,7 @@ fi
 if [[ -f "$file" ]]; then
   exec bash -lc "octave --no-gui -q --persist \"$file\" 2>/dev/null"
 else
-  echo ">> No se recibió argumento ?arg=<script>.m válido – abriendo REPL"
+  echo ">> No se encontró script .m válido – abriendo REPL"
   exec bash -lc "octave --no-gui -q --persist"
 fi
+


### PR DESCRIPTION
## Summary
- run first available Octave script if no argument is provided
- clarify error message when no script is found

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897e22cce7c8321be9b565f57c81ef6