### PR TITLE
Handle key-value exercise argument for Octave web

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 # Primer argumento que llega vía ?arg=<fichero.m>
 file="$1"
 
+# Acepta parámetros tipo clave=valor (p.ej. exercise=Longitud.m)
+if [[ "$file" == *=* ]]; then
+  file="${file#*=}"
+fi
+
 # Si viene solo el nombre, lo buscamos en /opt/exercises
 if [[ -n "$file" ]]; then
   [[ -f "/opt/exercises/$file" ]] && file="/opt/exercises/$file"
@@ -10,6 +15,6 @@ fi
 if [[ -f "$file" ]]; then
   exec bash -lc "octave --no-gui -q --persist \"$file\" 2>/dev/null"
 else
-  echo ">> No se recibió argumento ?arg=<script>.m válido – abriendo REPL"
+  echo ">> No se recibió argumento ?arg=<script>.m ni ?exercise=<script>.m válido – abriendo REPL"
   exec bash -lc "octave --no-gui -q --persist"
 fi


### PR DESCRIPTION
## Summary
- allow entrypoint.sh to accept script names passed as `key=value` (e.g. `?exercise=Longitud_Tuberia.m`)
- clarify error message when no valid script argument is provided

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6898042d716483218ce3452ea44f4a1e