### PR TITLE
Suppress Octave startup message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8080
+# Ejecutar Octave en modo silencioso para evitar el mensaje inicial
 CMD ["gotty", "--permit-write", "--port", "8080", \
-      "bash", "-lc", "octave --persist Longitud_Tuberia.m 2>/dev/null"]
+      "bash", "-lc", "octave --no-gui -q --persist Longitud_Tuberia.m 2>/dev/null"]
 


### PR DESCRIPTION
## Summary
- Run Octave in quiet mode in the default container command to remove the startup banner

## Testing
- `bash -n entrypoint.sh`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980a4f5fb083219b6a7fa89d723e5b