### PR TITLE
Add minimal Octave-like web terminal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,75 @@
+const form = document.getElementById('input-form');
+const input = document.getElementById('input');
+const output = document.getElementById('output');
+const varsDiv = document.getElementById('variables');
+const variables = {};
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const cmd = input.value.trim();
+  if (cmd === '') return;
+  print(`octave> ${cmd}`);
+  processCommand(cmd);
+  input.value = '';
+});
+
+function print(text) {
+  const line = document.createElement('div');
+  line.textContent = text;
+  output.appendChild(line);
+  output.scrollTop = output.scrollHeight;
+}
+
+function processCommand(cmd) {
+  const assignMatch = cmd.match(/^([a-zA-Z]\w*)\s*=\s*(.+)$/);
+  if (assignMatch) {
+    const name = assignMatch[1];
+    const expr = assignMatch[2];
+    try {
+      const value = evaluate(expr);
+      variables[name] = value;
+      print(String(value));
+      updateVariables();
+    } catch (err) {
+      print(`error: ${err.message}`);
+    }
+  } else if (cmd === 'clear') {
+    for (const k in variables) delete variables[k];
+    output.textContent = '';
+    updateVariables();
+  } else {
+    try {
+      const value = evaluate(cmd);
+      if (value !== undefined) {
+        print(String(value));
+      }
+    } catch (err) {
+      print(`error: ${err.message}`);
+    }
+  }
+}
+
+function evaluate(expr) {
+  const names = Object.keys(variables);
+  const params = names.join(',');
+  const values = names.map(n => variables[n]);
+  const func = new Function(params, `with (Math) { return ${expr}; }`);
+  return func(...values);
+}
+
+function updateVariables() {
+  varsDiv.innerHTML = '';
+  for (const [name, value] of Object.entries(variables)) {
+    const div = document.createElement('div');
+    div.className = 'variable';
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'name';
+    nameSpan.textContent = `${name} = `;
+    const valueSpan = document.createElement('span');
+    valueSpan.className = 'value';
+    valueSpan.textContent = value;
+    div.appendChild(nameSpan);
+    div.appendChild(valueSpan);
+    varsDiv.appendChild(div);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Octave Web Terminal</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <div class="terminal-panel">
+      <div id="output"></div>
+      <form id="input-form">
+        <span class="prompt">octave&gt; </span>
+        <input type="text" id="input" autocomplete="off" autofocus />
+      </form>
+    </div>
+    <div class="variables-panel">
+      <h2>Variables</h2>
+      <div id="variables"></div>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,66 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: monospace;
+}
+.container {
+  display: flex;
+  height: 100%;
+}
+.terminal-panel {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+  background: #000;
+  color: #fff;
+}
+#output {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+#input-form {
+  display: flex;
+  padding: 5px;
+  background: #111;
+}
+#input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #0f0;
+  outline: none;
+  font-family: inherit;
+}
+.prompt {
+  color: #0f0;
+  margin-right: 5px;
+}
+.variables-panel {
+  flex: 1;
+  background: #2b2b2b;
+  color: #fff;
+  padding: 10px;
+  overflow-y: auto;
+}
+.variables-panel h2 {
+  margin-top: 0;
+}
+.variable {
+  margin-bottom: 5px;
+}
+.variable .name {
+  color: #fff;
+}
+.variable .value {
+  color: #0af;
+}
+@media (max-width: 600px) {
+  .container {
+    flex-direction: column;
+  }
+  .variables-panel {
+    order: -1;
+    flex: none;
+  }
+}


### PR DESCRIPTION
## Summary
- build responsive web page with left Octave-style terminal and right variable sidebar
- track assignments, update variable list, support basic expression evaluation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e99fa3e88321916f2ffc57f13ff5