### PR TITLE
Add minimalist Octave web interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,21 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>Octave Web Terminal</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <iframe id="terminal" src="http://localhost:8080" title="Octave Terminal"></iframe>
+  <div id="left-panel">
+    <iframe id="terminal" src="http://localhost:8080" title="Octave Terminal"></iframe>
+    <div id="command-bar">
+      <input id="command-input" type="text" placeholder="Escribe un comando y presiona Enter" />
+    </div>
+  </div>
+  <aside id="variables-panel">
+    <h2>Variables</h2>
+    <ul id="variables-list"></ul>
+  </aside>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,45 @@
+const terminalFrame = document.getElementById('terminal');
+const cmdInput = document.getElementById('command-input');
+const varsList = document.getElementById('variables-list');
+
+cmdInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    const cmd = cmdInput.value.trim();
+    if (cmd !== '') {
+      terminalFrame.contentWindow.postMessage(cmd, '*');
+      cmdInput.value = '';
+      fetchVariables();
+    }
+  }
+});
+
+async function fetchVariables() {
+  try {
+    const res = await fetch('/variables');
+    if (!res.ok) return;
+    const vars = await res.json();
+    renderVariables(vars);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function renderVariables(vars) {
+  varsList.innerHTML = '';
+  Object.entries(vars).forEach(([name, value]) => {
+    const li = document.createElement('li');
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'var-name';
+    nameSpan.textContent = name + ' = ';
+    const valueSpan = document.createElement('span');
+    const className = isNaN(Number(value)) ? 'var-non-num' : 'var-num';
+    valueSpan.className = `var-value ${className}`;
+    valueSpan.textContent = value;
+    li.appendChild(nameSpan);
+    li.appendChild(valueSpan);
+    varsList.appendChild(li);
+  });
+}
+
+setInterval(fetchVariables, 2000);

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,79 @@
 html, body {
   height: 100%;
   margin: 0;
+  font-family: monospace;
+}
+
+body {
+  display: flex;
+  background: #000;
+  color: #eee;
+}
+
+#left-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #000;
 }
 
 #terminal {
+  flex: 1;
+  border: none;
+  background: #000;
+}
+
+#command-bar {
+  background: #111;
+  border-top: 1px solid #333;
+  padding: 4px;
+}
+
+#command-input {
   width: 100%;
-  height: 100%;
-  border: 0;
+  background: #111;
+  color: #eee;
+  border: none;
+  outline: none;
+  padding: 6px;
+}
+
+#command-input:focus {
+  background: #1a1a1a;
+}
+
+#variables-panel {
+  width: 250px;
+  background: #1e1e1e;
+  padding: 10px;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+#variables-panel h2 {
+  margin-top: 0;
+  font-size: 16px;
+  color: #ccc;
+}
+
+#variables-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#variables-list li {
+  margin-bottom: 4px;
+}
+
+.var-name {
+  color: #ddd;
+}
+
+.var-value.var-num {
+  color: #4caf50;
+}
+
+.var-value.var-non-num {
+  color: #2196f3;
 }


### PR DESCRIPTION
## Summary
- embed GoTTY terminal alongside variable sidebar and command input
- style layout with dark theme and color-coded variable values
- add JavaScript to send commands and poll variables

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee600ef48321895a7553750d9b23