### PR TITLE
Serve Octave terminal with static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:bookworm-slim
 # ------------------------------
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        octave gnuplot-nox ca-certificates curl && \
+        octave gnuplot-nox ca-certificates curl python3 && \
     rm -rf /var/lib/apt/lists/*
 ENV GNUTERM=dumb
 
@@ -19,13 +19,21 @@ RUN curl -L https://github.com/yudai/gotty/releases/download/v${GOTTY_VERSION}/g
     chmod +x /usr/local/bin/gotty
 
 # ------------------------------
-# 3) Ejercicios
+# 3) Archivos de ejercicios
 # ------------------------------
 WORKDIR /opt/exercises
 COPY *.m .
 
-EXPOSE 8080
-# Ejecutar Octave en modo silencioso para evitar el mensaje inicial
-CMD ["gotty", "--permit-write", "--port", "8080", \
-      "bash", "-lc", "octave --no-gui -q --persist Longitud_Tuberia.m 2>/dev/null"]
+# ------------------------------
+# 4) Archivos web estáticos
+# ------------------------------
+WORKDIR /opt/web
+COPY index.html script.js styles.css ./
+
+COPY start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
+EXPOSE 80 8080
+
+CMD ["/usr/local/bin/start.sh"]
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Iniciar servidor web estático
+python3 -m http.server 80 --directory /opt/web &
+
+# Lanzar GoTTY con Octave
+cd /opt/exercises
+exec gotty --permit-write --port 8080 bash -lc "octave --no-gui -q --persist Longitud_Tuberia.m 2>/dev/null"


### PR DESCRIPTION
## Summary
- install python and add start script to launch web server and GoTTY
- include HTML/CSS/JS assets in image and expose ports 80 and 8080

## Testing
- `docker build -t test-image .` *(fails: bash: command not found: docker)*
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898efe9ffe8832187fc834dd5ddccb6