### PR TITLE
Handle invalid input without Octave exit exception

### DIFF
--- a/Longitud_Tuberia.m
+++ b/Longitud_Tuberia.m
@@ -6,7 +6,10 @@ dy_dx  = @(x) x;
 
 a = input('Ingrese el límite inferior (a): ');
 b = input('Ingrese el límite superior (b): ');
-if a >= b, error('a debe ser < b'); end
+if a >= b
+  fprintf(2, 'Error: a debe ser < b\n');
+  return;
+end
 
 integrand   = @(x) sqrt(1 + (dy_dx(x)).^2);
 arc_length = integral(integrand, a, b);
@@ -29,5 +32,4 @@ system(cmd);
 delete(tmp);
 
 fprintf('\nLongitud de arco en [%0.2f,%0.2f] ≈ %0.4f\n', a, b, arc_length);
-exit(0);
 


### PR DESCRIPTION
## Summary
- Avoid Octave exit exception by displaying input error without throwing
- Remove explicit `exit` call so script terminates cleanly

## Testing
- `printf "0\n1\n" | octave --no-gui -q Longitud_Tuberia.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b86c3bf48321b776b1f904a7f293